### PR TITLE
Env configs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,21 @@
 FROM clojure:lein-2.5.1
 MAINTAINER Democracy Works, Inc. <dev@democracy.works>
 
+RUN mkdir -p /opt/didor
+WORKDIR /opt/didor
+
+RUN apt-get update && apt-get upgrade -y # last updated 20150416
+RUN apt-get install -y ruby jq
+RUN gem install bundler
+
+COPY ./Gemfile /opt/didor/Gemfile
+COPY ./Gemfile.lock /opt/didor/Gemfile.lock
+RUN bundle install
+
+COPY ./read_edn.rb /opt/didor/read_edn.rb
+
 ADD ./deploy-or-run /bin/deploy-or-run
+
+EXPOSE 8080
 
 CMD ["/bin/deploy-or-run"]

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org/"
+
+gem 'edn', '~> 1.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,10 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    edn (1.0.6)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  edn (~> 1.0.2)

--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ CMD ["/opt/jboss/wildfly/bin/standalone.sh", "-b", "0.0.0.0", "-bmanagement", "0
 
 ## Building the docker image
 
-From in the `didor/` dir
-
 ```
 > docker build -t your.repo/didor .
 > docker push your.repo/didor

--- a/deploy-or-run
+++ b/deploy-or-run
@@ -26,9 +26,10 @@ function wildfly_operation {
   return 0
 }
 
-function build_war {
+function ensure_war {
   if [[ ! -e target/${APP}.war ]]; then
-    lein immutant war
+    echo "NOTICE: No ${APP}.war file found in /target dir. Building it now..."
+    lein immutant war --name ${APP} --destination-dir target
   fi
 }
 
@@ -37,12 +38,13 @@ function configure_war {
   local cwd=$(pwd)
   local tmpdir=${cwd}/target/tmp
   mkdir -p $tmpdir
-  cd /opt/didor && bundle exec ./read_edn.rb ${cwd}/resources/config.edn > ${tmpdir}/config.edn && cd ${cwd}
+  cd /opt/didor && bundle exec ./read_edn.rb ${cwd}/resources/config.edn > ${tmpdir}/config.edn
   echo "WAR config: $(<${tmpdir}/config.edn)"
   cd ${tmpdir}
   jar -xf ../${APP}.war WEB-INF/lib/${APP}.jar
   jar -uf WEB-INF/lib/${APP}.jar -C ${tmpdir} config.edn
   jar -uf ../${APP}.war WEB-INF/lib/${APP}.jar
+  cd ${cwd}
   rm -rf ${tmpdir}
 }
 
@@ -63,8 +65,8 @@ function deploy_failure {
 trap undeploy EXIT
 
 if [[ -n "${NO_LEIN_RUN}" || -n "${WILDFLY_PORT_9990_TCP_ADDR}" ]]; then
-  echo "Building and/or configuring ${APP} WAR file..."
-  build_war
+  ensure_war
+  echo "Configuring ${APP} WAR file..."
   configure_war
   echo "Waiting for WildFly at ${WILDFLY_PORT_9990_TCP_ADDR}:${WILDFLY_PORT_9990_TCP_PORT} ... "
   while ! nc -q 1 $WILDFLY_PORT_9990_TCP_ADDR $WILDFLY_PORT_9990_TCP_PORT </dev/null; do sleep 1; done
@@ -83,6 +85,6 @@ if [[ -n "${NO_LEIN_RUN}" || -n "${WILDFLY_PORT_9990_TCP_ADDR}" ]]; then
   echo "Done."
   sleep infinity
 else
-  echo "Didor: No WildFly container found, using lein run"
+  echo "No WildFly container found, using lein run"
   exec lein run
 fi

--- a/deploy-or-run
+++ b/deploy-or-run
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 APP=$(grep defproject project.clj | awk '{print $2}')
 
 if [[ -n "${WILDFLY_PORT_9990_TCP_ADDR}" ]]; then
@@ -24,6 +26,26 @@ function wildfly_operation {
   return 0
 }
 
+function build_war {
+  if [[ ! -e target/${APP}.war ]]; then
+    lein immutant war
+  fi
+}
+
+function configure_war {
+  # render env vars into the config file before we build the WAR file
+  local cwd=$(pwd)
+  local tmpdir=${cwd}/target/tmp
+  mkdir -p $tmpdir
+  cd /opt/didor && bundle exec ./read_edn.rb ${cwd}/resources/config.edn > ${tmpdir}/config.edn && cd ${cwd}
+  echo "WAR config: $(<${tmpdir}/config.edn)"
+  cd ${tmpdir}
+  jar -xf ../${APP}.war WEB-INF/lib/${APP}.jar
+  jar -uf WEB-INF/lib/${APP}.jar -C ${tmpdir} config.edn
+  jar -uf ../${APP}.war WEB-INF/lib/${APP}.jar
+  rm -rf ${tmpdir}
+}
+
 function undeploy {
   if [[ "${DEPLOYED}" == "yes" ]]; then
     echo "Undeploying ${APP}... "
@@ -40,7 +62,10 @@ function deploy_failure {
 
 trap undeploy EXIT
 
-if [[ -n "${WILDFLY_PORT_9990_TCP_ADDR}" ]]; then
+if [[ -n "${NO_LEIN_RUN}" || -n "${WILDFLY_PORT_9990_TCP_ADDR}" ]]; then
+  echo "Building and/or configuring ${APP} WAR file..."
+  build_war
+  configure_war
   echo "Deploying ${APP} to WildFly... "
   WILDFLY_RESPONSE=$(curl -s -S -F "file=@target/${APP}.war" --digest ${WILDFLY_ADMIN_URL}/add-content)
   WILDFLY_CONTENT=$(echo "${WILDFLY_RESPONSE}" | jq -c 'if .outcome == "success" then .result else "error" end')
@@ -56,5 +81,6 @@ if [[ -n "${WILDFLY_PORT_9990_TCP_ADDR}" ]]; then
   echo "Done."
   sleep infinity
 else
+  echo "Didor: No WildFly container found, using lein run"
   exec lein run
 fi

--- a/read_edn.rb
+++ b/read_edn.rb
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+
+require 'edn'
+
+edn_file = ARGV.first
+
+EDN.register("resource-config/env") do |env_var|
+  ENV[env_var]
+end
+
+File.open(edn_file) do |f|
+  puts EDN.read(f).to_edn
+end


### PR DESCRIPTION
This writes env var values into the war file's config.edn before deploying to WildFly.

Assigning @tank157.

No card, but it is needed to deploy things to WildFly that use env vars for config (which is pretty much everything, or soon will be).
