### PR TITLE
Improve wait for wildfly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN mkdir -p /opt/didor
 WORKDIR /opt/didor
 
 RUN apt-get update && apt-get upgrade -y # last updated 20150416
-RUN apt-get install -y ruby jq curl netcat
+RUN apt-get install -y ruby jq curl
 RUN gem install bundler
 
 COPY ./Gemfile /opt/didor/Gemfile

--- a/deploy-or-run
+++ b/deploy-or-run
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+set -o pipefail
 
 APP=$(grep defproject project.clj | awk '{print $2}')
 
@@ -65,7 +66,7 @@ function deploy_failure {
 function wait_for_wildfly {
   echo "Waiting for WildFly at ${WILDFLY_PORT_9990_TCP_ADDR} ${WILDFLY_PORT_9990_TCP_PORT} ... "
   for i in {1..30}; do
-    if nc -q 1 $WILDFLY_PORT_9990_TCP_ADDR $WILDFLY_PORT_9990_TCP_PORT </dev/null; then
+    if curl -sf --digest $WILDFLY_ADMIN_URL | jq '.' >/dev/null 2>&1; then
       echo "Wildfly is there!"
       return 0
     fi


### PR DESCRIPTION
This switches wait_for_wildfly from checking that the management API port is open to checking that we can curl it and get valid JSON from it.

I was getting lots of krakenstein startup failures in cases where the port was open but it wasn't yet ready to receive deployments. These were the "parse error: Invalid numeric literal on line N, column M" errors that some others had seen.
