### PR TITLE
sleep loop index secs instead of 1

### DIFF
--- a/deploy-or-run
+++ b/deploy-or-run
@@ -71,7 +71,7 @@ function wait_for_wildfly {
       return 0
     fi
     echo "WildFly not found, waiting..."
-    sleep 1
+    sleep $i
   done
   deploy_failure "Could not find Wildfly at ${WILDFLY_PORT_9990_TCP_ADDR} ${WILDFLY_PORT_9990_TCP_PORT}"
   return 1


### PR DESCRIPTION
This will make us wait 1 second between the 1st and 2nd WildFly checks,
2 seconds between the 2nd and 3rd, etc.

I was seeing it hit 30 and giving up before WildFly was ready in large
docker-compose stacks.
