### PR TITLE
update to lein-2.5.2 upstream image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM clojure:lein-2.5.1
+FROM clojure:lein-2.5.2
 MAINTAINER Democracy Works, Inc. <dev@democracy.works>
 
 RUN mkdir -p /opt/didor


### PR DESCRIPTION
This also bumps us from Java 7 to Java 8 because the upstream Dockerfile made that transition in the 2.5.1 -> 2.5.2 release. But that seems like a good thing. (We're already running the compiled WARs under Java 8 on the WildFlys, for instance.)
