### PR TITLE
Convert to apline-based upstream image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
-FROM clojure:lein-2.5.3
+FROM clojure:lein-2.6.1-alpine
 MAINTAINER Democracy Works, Inc. <dev@democracy.works>
 
 RUN mkdir -p /opt/didor
 WORKDIR /opt/didor
 
-RUN apt-get update && apt-get upgrade -y # last updated 20151109
-RUN apt-get install -y ruby jq curl
-RUN gem install bundler --no-document
+RUN apk add --update ruby ruby-dev build-base jq curl
+RUN gem install bundler io-console --no-document
 
 COPY ./Gemfile /opt/didor/Gemfile
 COPY ./Gemfile.lock /opt/didor/Gemfile.lock


### PR DESCRIPTION
This is the image that most of our server-side Clojure components derive from. I will push this to Quay.io with an `:alpine` tag for now so we can convert and test downstream components. But let's get this party started!

No card; just a lunch break experiment.
